### PR TITLE
fix(security): prevent script injection in hub command

### DIFF
--- a/.github/workflows/update_code.yml
+++ b/.github/workflows/update_code.yml
@@ -22,8 +22,9 @@ jobs:
           token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Checkout Pull Request
-        run: hub pr checkout ${{ github.event.issue.number }}
+        run: hub pr checkout $PR_NUMBER
         env:
+          PR_NUMBER: ${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 11
         uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1


### PR DESCRIPTION

This PR mitigates a Script Injection vulnerability in the `update_code.yml` workflow.

The direct use of `${{ github.event.issue.number }}` within the `hub pr checkout` command has been replaced with an intermediate environment variable (`$PR_NUMBER`).
This prevents potential shell interpretation issues and follows GitHub Actions security best practices.
